### PR TITLE
feat: add Switchers class

### DIFF
--- a/src/js/const/selects.js
+++ b/src/js/const/selects.js
@@ -1,0 +1,11 @@
+const SELECTS = {
+  valueName: ['Cases', 'Deaths', 'Recovered'],
+  period: ['All time', 'Last Day'],
+  valueType: ['Absolute', 'Per 100k'],
+  tableSelects: ['period', 'valueType'],
+  mapSelects: ['valueName', 'period', 'valueType'],
+  listSelects: ['period', 'valueType'],
+  chartSelects: ['valueName', 'period', 'valueType'],
+};
+
+export default SELECTS;

--- a/src/js/switchers.js
+++ b/src/js/switchers.js
@@ -1,0 +1,44 @@
+import createElement from './utils/create-element';
+import SELECTS from './const/selects';
+
+/**
+ * Get markup for one switcher.
+ * @param {array} switcherOptions - Array of switcher options;
+ * @returns {string} Switcher markup.
+ */
+function getSwitcherOptions(switcherOptions) {
+  let result = '';
+  switcherOptions.forEach((option) => {
+    const optionValue = option.toLowerCase().split(' ').join('-');
+    result += `<option value="${optionValue}">${option}</option>\n`;
+  });
+  return result;
+}
+
+/**
+ * Get markup for specified switchers.
+ * @param {array} selects - Array of switchers which are to be included.
+ * @returns {string} String with switchers markup.
+ */
+function getSwitchers(selects) {
+  let result = '';
+  selects.forEach((select) => {
+    const selectOptions = getSwitcherOptions(SELECTS[select]);
+    result += `<select class="switchers__switcher switchers__switcher--${select}" name="${select}">
+                ${selectOptions}
+              </select>`;
+  });
+  return result;
+}
+
+/**
+ * Class representing the switchers.
+ */
+export default class Switchers {
+  /**
+   * @param {array} selects - Array of switchers which are to be included.
+   */
+  constructor(selects) {
+    this.element = createElement('div', 'switchers', getSwitchers(selects));
+  }
+}

--- a/src/js/utils/create-element.js
+++ b/src/js/utils/create-element.js
@@ -1,0 +1,15 @@
+/**
+ * Create an HTML element with specified className and innerHTML.
+ * @param {string} tag - HTML tag.
+ * @param {string} className - Class or number of classes.
+ * @param {string} template - Inner HTML of created element.
+ * @returns {HTMLElement} - Created HTML element.
+ */
+export default function createElement(tag, className, template) {
+  const element = document.createElement(tag);
+  element.innerHTML = template;
+  if (className) {
+    element.className = className;
+  }
+  return element;
+}


### PR DESCRIPTION
Switchers are selects used to choose what kind of data should be represented in each of four Covid Dashbord elements. All four elements should have their own switchers.